### PR TITLE
Add Burn Fee to Token Minting Process

### DIFF
--- a/scripts/deployHybridMinterAndAvatar.ts
+++ b/scripts/deployHybridMinterAndAvatar.ts
@@ -223,8 +223,8 @@ const Kondux = await ethers.getContractFactory("Kondux");
  */
 
 const kondux = await Kondux.connect(signer).deploy(
-    "KonduxAvatar",          // _name
-    "KNDX_AVATAR",               // _symbol
+    "Kondux Avatars",          // _name
+    "kALN",               // _symbol
     uniswapPairAddress,   // _uniswapPair
     WETHAddress,          // _weth
     paymentTokenAddress,  // _kndx (the ERC20 token used to pay royalties)
@@ -233,7 +233,7 @@ const kondux = await Kondux.connect(signer).deploy(
     1000                  // _maxSupply
 );
  console.log("Arguments for hardhat verify:");
-    console.log(`KonduxAvatar KNDX_AVATAR ${uniswapPairAddress} ${WETHAddress} ${paymentTokenAddress} ${foundersPassAddress} ${treasuryAddress} 1000`);
+    console.log(`"Kondux Avatars" kALN ${uniswapPairAddress} ${WETHAddress} ${paymentTokenAddress} ${foundersPassAddress} ${treasuryAddress} 1000`);
 await kondux.waitForDeployment();
 kNFTAddress = kondux.target;
 console.log(`Kondux NFT contract deployed to: ${kNFTAddress}`);

--- a/test/KonduxTokenBasedMinter.test.js
+++ b/test/KonduxTokenBasedMinter.test.js
@@ -661,7 +661,7 @@ describe("KonduxTokenBasedMinter - Comprehensive Tests", function () {
             const paymentToken = await ethers.getContractAt("KNDX", PAYMENT_TOKEN_ADDRESS, user);
 
             // Define the amount of tokens the user needs to mint
-            const ethAmount = ethers.parseEther("0.225"); // 1 ETH
+            const ethAmount = ethers.parseEther("0.2"); // 1 ETH
             // get reserves from uniswap pair
             const uniswapPair = await ethers.getContractAt(uniswapPairABI, UNISWAP_PAIR_ADDRESS);
             const reserves = await uniswapPair.getReserves();
@@ -755,7 +755,7 @@ describe("KonduxTokenBasedMinter - Comprehensive Tests", function () {
             const paymentToken = await ethers.getContractAt("KNDX", PAYMENT_TOKEN_ADDRESS, user);
 
             // Define the amount of tokens the user needs to mint
-            const ethAmount = ethers.parseEther("0.225"); // 1 ETH
+            const ethAmount = ethers.parseEther("0.2"); // 1 ETH
             // get reserves from uniswap pair
             const uniswapPair = await ethers.getContractAt(uniswapPairABI, UNISWAP_PAIR_ADDRESS);
             const reserves = await uniswapPair.getReserves();
@@ -818,7 +818,7 @@ describe("KonduxTokenBasedMinter - Comprehensive Tests", function () {
             const paymentToken = await ethers.getContractAt("KNDX", PAYMENT_TOKEN_ADDRESS, user);
 
             // Define the amount of tokens the user needs to mint
-            const ethAmount = ethers.parseEther("0.225"); // 1 ETH
+            const ethAmount = ethers.parseEther("0.2"); // 1 ETH
             // get reserves from uniswap pair
             const uniswapPair = await ethers.getContractAt(uniswapPairABI, UNISWAP_PAIR_ADDRESS);
             const reserves = await uniswapPair.getReserves();
@@ -882,7 +882,7 @@ describe("KonduxTokenBasedMinter - Comprehensive Tests", function () {
             const paymentToken = await ethers.getContractAt("KNDX", PAYMENT_TOKEN_ADDRESS, user);
 
             // Define the amount of tokens the user needs to mint
-            const ethAmount = ethers.parseEther("0.225"); // 1 ETH
+            const ethAmount = ethers.parseEther("0.2"); // 1 ETH
             // get reserves from uniswap pair
             const uniswapPair = await ethers.getContractAt(uniswapPairABI, UNISWAP_PAIR_ADDRESS);
             const reserves = await uniswapPair.getReserves();
@@ -950,7 +950,7 @@ describe("KonduxTokenBasedMinter - Comprehensive Tests", function () {
             const paymentToken = await ethers.getContractAt("KNDX", PAYMENT_TOKEN_ADDRESS, user);
 
             // Define the amount of tokens the user needs to mint
-            const ethAmount = ethers.parseEther("0.225"); // .225 ETH
+            const ethAmount = ethers.parseEther("0.2"); // .225 ETH
             const uniswapPair = await ethers.getContractAt(uniswapPairABI, UNISWAP_PAIR_ADDRESS);
             const reserves = await uniswapPair.getReserves();
             const token0 = await uniswapPair.token0();
@@ -1041,7 +1041,7 @@ describe("KonduxTokenBasedMinter - Comprehensive Tests", function () {
             const paymentToken = await ethers.getContractAt("KNDX", PAYMENT_TOKEN_ADDRESS, user);
 
             // Define the amount of tokens the user needs to mint
-            const ethAmount = ethers.parseEther("0.225"); // 1 ETH
+            const ethAmount = ethers.parseEther("0.2"); // 1 ETH
             // get reserves from uniswap pair
             const uniswapPair = await ethers.getContractAt(uniswapPairABI, UNISWAP_PAIR_ADDRESS);
             const reserves = await uniswapPair.getReserves();
@@ -1274,7 +1274,7 @@ describe("KonduxTokenBasedMinter - Comprehensive Tests", function () {
             const paymentToken = await ethers.getContractAt("IKonduxERC20", PAYMENT_TOKEN_ADDRESS, user);
 
             // Define the amount of tokens the user needs to mint at founder discount
-            const ethAmount = ethers.parseEther("0.2"); // founderDiscountPrice
+            const ethAmount = ethers.parseEther("0.175"); // founderDiscountPrice
 
             // Fetch reserves from Uniswap pair
             const uniswapPair = await ethers.getContractAt(uniswapPairABI, UNISWAP_PAIR_ADDRESS);
@@ -1373,6 +1373,11 @@ describe("KonduxTokenBasedMinter - Comprehensive Tests", function () {
             // Save initial user token balance
             const initialUserBalance = await paymentToken.balanceOf(user.address);
 
+            // console log for the treasury address token balance before minting
+            const treasuryAddress = await konduxTokenBasedMinter.treasury();
+            const treasuryBalance = await paymentToken.balanceOf(treasuryAddress);
+            // console.log("Treasury balance before minting: ", treasuryBalance.toString());
+
             // Perform the minting and verify event emission
             await expect(konduxTokenBasedMinter.connect(user).publicMint())
                 .to.emit(konduxTokenBasedMinter, "BundleMinted")
@@ -1380,6 +1385,17 @@ describe("KonduxTokenBasedMinter - Comprehensive Tests", function () {
 
             // Capture the user's final token balance
             const finalUserBalance = await paymentToken.balanceOf(await user.getAddress());
+
+            // console log for the treasury address token balance after minting
+            const finalTreasuryBalance = await paymentToken.balanceOf(treasuryAddress);
+            // console.log("Treasury balance after minting: ", finalTreasuryBalance.toString());
+
+            // check if treasury received the burn fee
+            const burnFeeBP = await konduxTokenBasedMinter.burnFeeBP();
+            const burnAmount = (tokensRequired * burnFeeBP) / 10_000n;
+            const treasuryAmount = tokensRequired - burnAmount;
+            expect(finalTreasuryBalance).to.equal(treasuryAmount + treasuryBalance);
+
 
             // Calculate expected tokens transferred (should be equal to tokensRequired)
             const tokensTransferred = BigInt(ethers.toBigInt(initialUserBalance)) - BigInt(ethers.toBigInt(finalUserBalance));


### PR DESCRIPTION
- Introduces a burn fee parameter in basis points, deducting a percentage of tokens on payments
- Splits token transfers into burn and treasury portions for improved fund handling
- Adds an admin function to adjust the burn fee with safeguard checks
- Updates pricing logic and test cases to reflect new fee mechanism and discount price changes